### PR TITLE
Add unit tests for photo data flow components

### DIFF
--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/MainDispatcherRule.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/MainDispatcherRule.kt
@@ -1,0 +1,26 @@
+package com.software.pandit.lyftlaptopinterview
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val dispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        super.starting(description)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/PhotoFlowIntegrationTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/PhotoFlowIntegrationTest.kt
@@ -1,0 +1,90 @@
+package com.software.pandit.lyftlaptopinterview
+
+import androidx.paging.AsyncPagingDataDiffer
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListUpdateCallback
+import com.google.common.truth.Truth.assertThat
+import com.software.pandit.lyftlaptopinterview.data.Photo
+import com.software.pandit.lyftlaptopinterview.data.PhotoPagingSource
+import com.software.pandit.lyftlaptopinterview.data.PhotoRepoImpl
+import com.software.pandit.lyftlaptopinterview.data.network.PhotoApi
+import com.software.pandit.lyftlaptopinterview.ui.photo.PhotoVm
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Provider
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PhotoFlowIntegrationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `photo vm exposes deduped photos from repo and paging source`() = runTest {
+        val photo1 = createPhoto(id = "1")
+        val photo2 = createPhoto(id = "2")
+        val duplicatePhoto2 = createPhoto(id = "2")
+        val duplicateAcrossPages = createPhoto(id = "2")
+        val photo3 = createPhoto(id = "3")
+
+        val api = QueuePhotoApi(
+            mutableListOf(
+                mutableListOf(
+                    photo1,
+                    photo2,
+                    duplicatePhoto2
+                ),
+                mutableListOf(
+                    duplicateAcrossPages,
+                    photo3
+                )
+            )
+        )
+        val repo = PhotoRepoImpl(Provider { PhotoPagingSource(api, clientId = "client") })
+        val viewModel = PhotoVm(repo)
+
+        val differ = AsyncPagingDataDiffer(
+            diffCallback = object : DiffUtil.ItemCallback<Photo>() {
+                override fun areItemsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem.id == newItem.id
+                override fun areContentsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem == newItem
+            },
+            updateCallback = NoopListCallback,
+            mainDispatcher = mainDispatcherRule.dispatcher,
+            workerDispatcher = mainDispatcherRule.dispatcher
+        )
+
+        val pagingData = viewModel.photos.first()
+        differ.submitData(pagingData)
+        advanceUntilIdle()
+
+        // Trigger append load for the second page
+        differ[2]
+        advanceUntilIdle()
+
+        assertThat(differ.snapshot()).containsExactly(
+            photo1,
+            photo2,
+            photo3
+        ).inOrder()
+    }
+
+    private object NoopListCallback : ListUpdateCallback {
+        override fun onInserted(position: Int, count: Int) {}
+        override fun onRemoved(position: Int, count: Int) {}
+        override fun onMoved(fromPosition: Int, toPosition: Int) {}
+        override fun onChanged(position: Int, count: Int, payload: Any?) {}
+    }
+
+    private class QueuePhotoApi(
+        private val responses: MutableList<MutableList<Photo>>
+    ) : PhotoApi {
+        override suspend fun getPhotos(page: Int, clientId: String): List<Photo> {
+            if (responses.isEmpty()) error("No response configured for page $page")
+            return responses.removeAt(0)
+        }
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/TestPhotoFactory.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/TestPhotoFactory.kt
@@ -7,53 +7,72 @@ import com.software.pandit.lyftlaptopinterview.data.Photo
 import com.software.pandit.lyftlaptopinterview.data.ProfileImage
 import com.software.pandit.lyftlaptopinterview.data.Urls
 
-fun createPhoto(id: String) = Photo(
-    blur_hash = "hash",
-    color = "#fff",
-    created_at = "2020-01-01T00:00:00Z",
-    current_user_collections = listOf(
-        CurrentUserCollection(
-            cover_photo = Any(),
-            id = 1,
-            last_collected_at = "2020-01-01T00:00:00Z",
-            published_at = "2020-01-01T00:00:00Z",
-            title = "title",
-            updated_at = "2020-01-01T00:00:00Z",
-            user = Any()
-        )
-    ),
-    description = "desc",
-    height = 100,
-    id = id,
-    liked_by_user = false,
-    likes = 0,
-    links = Links(
+/**
+ * Lightweight factory helpers for constructing photos and nested models in tests without
+ * repeating the huge amount of Unsplash payload boilerplate in every file.
+ */
+object TestPhotoFactory {
+
+    private val coverPhotoStub = Any()
+    private val userStub = Any()
+
+    fun photo(
+        id: String,
+        description: String? = "desc",
+        likes: Int = 0,
+        blurHash: String = "hash"
+    ): Photo = Photo(
+        blur_hash = blurHash,
+        color = "#fff",
+        created_at = "2020-01-01T00:00:00Z",
+        current_user_collections = listOf(
+            CurrentUserCollection(
+                cover_photo = coverPhotoStub,
+                id = 1,
+                last_collected_at = "2020-01-01T00:00:00Z",
+                published_at = "2020-01-01T00:00:00Z",
+                title = "title",
+                updated_at = "2020-01-01T00:00:00Z",
+                user = userStub
+            )
+        ),
+        description = description,
+        height = 100,
+        id = id,
+        liked_by_user = false,
+        likes = likes,
+        links = links(),
+        updated_at = "2020-01-02T00:00:00Z",
+        urls = urls(),
+        width = 100
+    )
+
+    fun links(): Links = Links(
         download = "download",
         download_location = "download_location",
         html = "html",
         self = "self"
-    ),
-    updated_at = "2020-01-02T00:00:00Z",
-    urls = Urls(
+    )
+
+    fun urls(): Urls = Urls(
         full = "full",
         raw = "raw",
         regular = "regular",
         small = "small",
         thumb = "thumb"
-    ),
-    width = 100
-)
+    )
 
-fun createLinksX() = LinksX(
-    html = "html",
-    likes = "likes",
-    photos = "photos",
-    portfolio = "portfolio",
-    self = "self"
-)
+    fun linksX(): LinksX = LinksX(
+        html = "html",
+        likes = "likes",
+        photos = "photos",
+        portfolio = "portfolio",
+        self = "self"
+    )
 
-fun createProfileImage() = ProfileImage(
-    large = "large",
-    medium = "medium",
-    small = "small"
-)
+    fun profileImage(): ProfileImage = ProfileImage(
+        large = "large",
+        medium = "medium",
+        small = "small"
+    )
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/TestPhotoFactory.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/TestPhotoFactory.kt
@@ -1,0 +1,59 @@
+package com.software.pandit.lyftlaptopinterview
+
+import com.software.pandit.lyftlaptopinterview.data.CurrentUserCollection
+import com.software.pandit.lyftlaptopinterview.data.Links
+import com.software.pandit.lyftlaptopinterview.data.LinksX
+import com.software.pandit.lyftlaptopinterview.data.Photo
+import com.software.pandit.lyftlaptopinterview.data.ProfileImage
+import com.software.pandit.lyftlaptopinterview.data.Urls
+
+fun createPhoto(id: String) = Photo(
+    blur_hash = "hash",
+    color = "#fff",
+    created_at = "2020-01-01T00:00:00Z",
+    current_user_collections = listOf(
+        CurrentUserCollection(
+            cover_photo = Any(),
+            id = 1,
+            last_collected_at = "2020-01-01T00:00:00Z",
+            published_at = "2020-01-01T00:00:00Z",
+            title = "title",
+            updated_at = "2020-01-01T00:00:00Z",
+            user = Any()
+        )
+    ),
+    description = "desc",
+    height = 100,
+    id = id,
+    liked_by_user = false,
+    likes = 0,
+    links = Links(
+        download = "download",
+        download_location = "download_location",
+        html = "html",
+        self = "self"
+    ),
+    updated_at = "2020-01-02T00:00:00Z",
+    urls = Urls(
+        full = "full",
+        raw = "raw",
+        regular = "regular",
+        small = "small",
+        thumb = "thumb"
+    ),
+    width = 100
+)
+
+fun createLinksX() = LinksX(
+    html = "html",
+    likes = "likes",
+    photos = "photos",
+    portfolio = "portfolio",
+    self = "self"
+)
+
+fun createProfileImage() = ProfileImage(
+    large = "large",
+    medium = "medium",
+    small = "small"
+)

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSourceTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSourceTest.kt
@@ -1,0 +1,138 @@
+package com.software.pandit.lyftlaptopinterview.data
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.google.common.truth.Truth.assertThat
+import com.software.pandit.lyftlaptopinterview.createPhoto
+import com.software.pandit.lyftlaptopinterview.data.network.PhotoApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PhotoPagingSourceTest {
+
+    private val photosForFirstPage = listOf(
+        createPhoto(id = "1"),
+        createPhoto(id = "2"),
+        createPhoto(id = "2")
+    )
+
+    private val photosForSecondPage = listOf(
+        createPhoto(id = "2"),
+        createPhoto(id = "3")
+    )
+
+    @Test
+    fun `load returns page with deduped photos`() = runTest {
+        val fakeApi = QueuePhotoApi(
+            mutableListOf(photosForFirstPage.toMutableList())
+        )
+        val pagingSource = PhotoPagingSource(fakeApi, "client")
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 10,
+                placeholdersEnabled = false
+            )
+        )
+
+        val page = result as PagingSource.LoadResult.Page
+        assertThat(page.data).containsExactly(
+            photosForFirstPage[0],
+            photosForFirstPage[1]
+        ).inOrder()
+        assertThat(page.prevKey).isNull()
+        assertThat(page.nextKey).isEqualTo(2)
+    }
+
+    @Test
+    fun `load filters duplicates seen across requests`() = runTest {
+        val fakeApi = QueuePhotoApi(
+            mutableListOf(
+                photosForFirstPage.toMutableList(),
+                photosForSecondPage.toMutableList()
+            )
+        )
+        val pagingSource = PhotoPagingSource(fakeApi, "client")
+
+        pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 10,
+                placeholdersEnabled = false
+            )
+        )
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Append(
+                key = 2,
+                loadSize = 10,
+                placeholdersEnabled = false
+            )
+        )
+
+        val page = result as PagingSource.LoadResult.Page
+        assertThat(page.data).containsExactly(photosForSecondPage[1])
+    }
+
+    @Test
+    fun `load returns error when api throws`() = runTest {
+        val fakeApi = object : PhotoApi {
+            override suspend fun getPhotos(page: Int, clientId: String): List<Photo> {
+                throw IllegalStateException("boom")
+            }
+        }
+        val pagingSource = PhotoPagingSource(fakeApi, "client")
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 10,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Error::class.java)
+    }
+
+    @Test
+    fun `getRefreshKey returns closest page key`() {
+        val pagingSource = PhotoPagingSource(QueuePhotoApi(mutableListOf()), "client")
+        val pagingState = PagingState(
+            pages = listOf(
+                PagingSource.LoadResult.Page(
+                    data = listOf(createPhoto("1")),
+                    prevKey = null,
+                    nextKey = 2
+                ),
+                PagingSource.LoadResult.Page(
+                    data = listOf(createPhoto("2")),
+                    prevKey = 2,
+                    nextKey = 4
+                )
+            ),
+            anchorPosition = 1,
+            config = androidx.paging.PagingConfig(
+                pageSize = 10,
+                prefetchDistance = 2,
+                enablePlaceholders = false
+            ),
+            leadingPlaceholderCount = 0
+        )
+
+        val refreshKey = pagingSource.getRefreshKey(pagingState)
+
+        assertThat(refreshKey).isEqualTo(3)
+    }
+
+    private class QueuePhotoApi(
+        private val responses: MutableList<MutableList<Photo>>
+    ) : PhotoApi {
+        override suspend fun getPhotos(page: Int, clientId: String): List<Photo> {
+            if (responses.isEmpty()) error("No response configured for page $page")
+            return responses.removeAt(0)
+        }
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepoImplTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepoImplTest.kt
@@ -1,46 +1,96 @@
 package com.software.pandit.lyftlaptopinterview.data
 
+import androidx.paging.AsyncPagingDataDiffer
 import androidx.paging.PagingData
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListUpdateCallback
 import com.google.common.truth.Truth.assertThat
+import com.software.pandit.lyftlaptopinterview.MainDispatcherRule
+import com.software.pandit.lyftlaptopinterview.TestPhotoFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import javax.inject.Provider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PhotoRepoImplTest {
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
     @Test
-    fun `getPhotos emits paging data and uses provider`() = runTest {
-        val pagingSource = FakePagingSource()
-        val provider = object : Provider<PhotoPagingSource> {
-            var invocationCount = 0
-            override fun get(): PhotoPagingSource {
-                invocationCount++
-                return pagingSource
-            }
-        }
+    fun `getPhotos collects paging data from provided paging source`() = runTest {
+        val provider = CountingProvider { RecordingPagingSource() }
         val repo = PhotoRepoImpl(provider)
 
         val pagingData = repo.getPhotos().first()
 
-        assertThat(provider.invocationCount).isEqualTo(1)
-        assertThat(pagingData).isInstanceOf(PagingData::class.java)
+        val differ = AsyncPagingDataDiffer(
+            diffCallback = object : DiffUtil.ItemCallback<Photo>() {
+                override fun areItemsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem.id == newItem.id
+                override fun areContentsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem == newItem
+            },
+            updateCallback = NoopListCallback,
+            mainDispatcher = mainDispatcherRule.dispatcher,
+            workerDispatcher = mainDispatcherRule.dispatcher
+        )
+
+        differ.submitData(pagingData)
+        advanceUntilIdle()
+        assertThat(provider.invocations).isEqualTo(1)
+        assertThat(provider.lastPagingSource.refreshInvocations).isEqualTo(1)
+        assertThat(differ.snapshot()).containsExactly(
+            TestPhotoFactory.photo(id = "from-paging-source")
+        )
     }
 
-    private class FakePagingSource : PhotoPagingSource(
+    private class CountingProvider(
+        private val delegate: () -> RecordingPagingSource
+    ) : Provider<PhotoPagingSource> {
+        var invocations = 0
+            private set
+        lateinit var lastPagingSource: RecordingPagingSource
+            private set
+
+        override fun get(): PhotoPagingSource {
+            invocations++
+            return delegate().also { lastPagingSource = it }
+        }
+    }
+
+    private class RecordingPagingSource : PhotoPagingSource(
         photoApi = object : com.software.pandit.lyftlaptopinterview.data.network.PhotoApi {
-            override suspend fun getPhotos(page: Int, clientId: String): List<Photo> = emptyList()
+            override suspend fun getPhotos(page: Int, clientId: String): List<Photo> =
+                listOf(TestPhotoFactory.photo(id = "from-paging-source"))
         },
         clientId = "client"
     ) {
+        var refreshInvocations = 0
+            private set
+
         override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Photo> {
-            return LoadResult.Page(emptyList(), prevKey = null, nextKey = null)
+            if (params is LoadParams.Refresh) {
+                refreshInvocations++
+            }
+            return LoadResult.Page(
+                data = listOf(TestPhotoFactory.photo(id = "from-paging-source")),
+                prevKey = null,
+                nextKey = null
+            )
         }
 
         override fun getRefreshKey(state: PagingState<Int, Photo>): Int? = null
+    }
+
+    private object NoopListCallback : ListUpdateCallback {
+        override fun onInserted(position: Int, count: Int) {}
+        override fun onRemoved(position: Int, count: Int) {}
+        override fun onMoved(fromPosition: Int, toPosition: Int) {}
+        override fun onChanged(position: Int, count: Int, payload: Any?) {}
     }
 }

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepoImplTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepoImplTest.kt
@@ -1,0 +1,46 @@
+package com.software.pandit.lyftlaptopinterview.data
+
+import androidx.paging.PagingData
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import javax.inject.Provider
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PhotoRepoImplTest {
+
+    @Test
+    fun `getPhotos emits paging data and uses provider`() = runTest {
+        val pagingSource = FakePagingSource()
+        val provider = object : Provider<PhotoPagingSource> {
+            var invocationCount = 0
+            override fun get(): PhotoPagingSource {
+                invocationCount++
+                return pagingSource
+            }
+        }
+        val repo = PhotoRepoImpl(provider)
+
+        val pagingData = repo.getPhotos().first()
+
+        assertThat(provider.invocationCount).isEqualTo(1)
+        assertThat(pagingData).isInstanceOf(PagingData::class.java)
+    }
+
+    private class FakePagingSource : PhotoPagingSource(
+        photoApi = object : com.software.pandit.lyftlaptopinterview.data.network.PhotoApi {
+            override suspend fun getPhotos(page: Int, clientId: String): List<Photo> = emptyList()
+        },
+        clientId = "client"
+    ) {
+        override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Photo> {
+            return LoadResult.Page(emptyList(), prevKey = null, nextKey = null)
+        }
+
+        override fun getRefreshKey(state: PagingState<Int, Photo>): Int? = null
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/network/NetworkModuleTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/network/NetworkModuleTest.kt
@@ -1,0 +1,76 @@
+package com.software.pandit.lyftlaptopinterview.data.network
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+class NetworkModuleTest {
+
+    private val module = NetworkModule()
+
+    @Test
+    fun `provideBaseUrl returns unsplash url`() {
+        val baseUrl = module.provideBaseUrl()
+        assertThat(baseUrl).isEqualTo("https://api.unsplash.com/")
+    }
+
+    @Test
+    fun `provideApiKey returns expected key`() {
+        val apiKey = module.provideApiKey()
+        assertThat(apiKey).isEqualTo("V3sVfbkaOuBlwSD_BEqMSyJAB5gYectrTFl6-NrYyTM")
+    }
+
+    @Test
+    fun `provideLoggingInterceptor sets body level`() {
+        val interceptor = module.provideLoggingInterceptor()
+        assertThat(interceptor).isInstanceOf(HttpLoggingInterceptor::class.java)
+        assertThat(interceptor.level).isEqualTo(HttpLoggingInterceptor.Level.BODY)
+    }
+
+    @Test
+    fun `provideOkHttpClient configures timeouts and interceptor`() {
+        val logging = HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.HEADERS }
+        val client = module.provideOkHttpClient(logging)
+        assertThat(client.connectTimeoutMillis.toLong()).isEqualTo(20_000)
+        assertThat(client.readTimeoutMillis.toLong()).isEqualTo(20_000)
+        assertThat(client.writeTimeoutMillis.toLong()).isEqualTo(20_000)
+        assertThat(client.interceptors).contains(logging)
+    }
+
+    @Test
+    fun `provideMoshi returns builder instance`() {
+        val moshi = module.provideMoshi()
+        assertThat(moshi).isInstanceOf(Moshi::class.java)
+    }
+
+    @Test
+    fun `provideRetrofit builds retrofit with moshi and client`() {
+        val baseUrl = module.provideBaseUrl()
+        val logging = module.provideLoggingInterceptor()
+        val client = module.provideOkHttpClient(logging)
+        val moshi = module.provideMoshi()
+
+        val retrofit = module.provideRetrofit(baseUrl, client, moshi)
+
+        assertThat(retrofit).isInstanceOf(Retrofit::class.java)
+        assertThat(retrofit.baseUrl().toString()).isEqualTo(baseUrl)
+        assertThat(retrofit.callFactory()).isEqualTo(client)
+    }
+
+    @Test
+    fun `getPhotoApi creates retrofit service`() {
+        val retrofit = Retrofit.Builder()
+            .baseUrl("https://api.unsplash.com/")
+            .client(OkHttpClient())
+            .addConverterFactory(MoshiConverterFactory.create())
+            .build()
+
+        val api = module.getPhotoApi(retrofit)
+
+        assertThat(api).isNotNull()
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoVmTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoVmTest.kt
@@ -6,7 +6,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListUpdateCallback
 import com.google.common.truth.Truth.assertThat
 import com.software.pandit.lyftlaptopinterview.MainDispatcherRule
-import com.software.pandit.lyftlaptopinterview.createPhoto
+import com.software.pandit.lyftlaptopinterview.TestPhotoFactory
 import com.software.pandit.lyftlaptopinterview.data.Photo
 import com.software.pandit.lyftlaptopinterview.data.PhotoRepo
 import app.cash.turbine.test
@@ -30,7 +30,7 @@ class PhotoVmTest {
     @Test
     fun `photos flow emits data from repo`() = runTest {
         val vm = PhotoVm(fakeRepo)
-        val photo = createPhoto("1")
+        val photo = TestPhotoFactory.photo("1")
         fakeRepo.emit(PagingData.from(listOf(photo)))
 
         val differ = AsyncPagingDataDiffer(

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoVmTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoVmTest.kt
@@ -1,0 +1,71 @@
+package com.software.pandit.lyftlaptopinterview.ui.photo
+
+import androidx.paging.AsyncPagingDataDiffer
+import androidx.paging.PagingData
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListUpdateCallback
+import com.google.common.truth.Truth.assertThat
+import com.software.pandit.lyftlaptopinterview.MainDispatcherRule
+import com.software.pandit.lyftlaptopinterview.createPhoto
+import com.software.pandit.lyftlaptopinterview.data.Photo
+import com.software.pandit.lyftlaptopinterview.data.PhotoRepo
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PhotoVmTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val fakeRepo = FakePhotoRepo()
+
+    @Test
+    fun `photos flow emits data from repo`() = runTest {
+        val vm = PhotoVm(fakeRepo)
+        val photo = createPhoto("1")
+        fakeRepo.emit(PagingData.from(listOf(photo)))
+
+        val differ = AsyncPagingDataDiffer(
+            diffCallback = object : DiffUtil.ItemCallback<Photo>() {
+                override fun areItemsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem.id == newItem.id
+                override fun areContentsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem == newItem
+            },
+            updateCallback = NoopListCallback,
+            mainDispatcher = mainDispatcherRule.dispatcher,
+            workerDispatcher = mainDispatcherRule.dispatcher
+        )
+
+        vm.photos.test {
+            val pagingData = awaitItem()
+            differ.submitData(pagingData)
+            advanceUntilIdle()
+            assertThat(differ.snapshot()).containsExactly(photo)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private object NoopListCallback : ListUpdateCallback {
+        override fun onInserted(position: Int, count: Int) {}
+        override fun onRemoved(position: Int, count: Int) {}
+        override fun onMoved(fromPosition: Int, toPosition: Int) {}
+        override fun onChanged(position: Int, count: Int, payload: Any?) {}
+    }
+
+    private class FakePhotoRepo : PhotoRepo {
+        private val sharedFlow = MutableSharedFlow<PagingData<Photo>>(replay = 1)
+
+        override fun getPhotos(): Flow<PagingData<Photo>> = sharedFlow.asSharedFlow()
+
+        suspend fun emit(data: PagingData<Photo>) {
+            sharedFlow.emit(data)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add coroutine dispatcher rule and reusable photo factory for tests
- cover PhotoPagingSource and PhotoRepo behaviors with unit tests
- add tests for PhotoVm and NetworkModule wiring

## Testing
- `./gradlew test` *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c7b3c954832482c199d048f17453