### PR TITLE
Introduce domain models and UI state for photos

### DIFF
--- a/ARCHITECTURE_REVIEW.md
+++ b/ARCHITECTURE_REVIEW.md
@@ -1,0 +1,27 @@
+# Architecture Review
+
+## Overall Rating
+**Score: 6 / 10** — The project follows several of Google's recommended Android architecture practices (unidirectional data flow, dependency injection, Jetpack libraries), but important gaps remain around layering, state modeling, and configuration management that keep it from being production-ready.
+
+## Strengths
+- **Dependency injection is in place.** The app uses Hilt modules to provide networking dependencies and bind the repository interface to its implementation, which keeps construction logic centralized and testable.【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/data/DataModule.kt†L9-L17】【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/data/network/NetworkModule.kt†L16-L76】
+- **UI observes a reactive data source.** `PhotoVm` exposes a Paging `Flow` that the Compose UI collects, giving you a single source of truth for the list and aligning with the recommended unidirectional data flow pattern.【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoVm.kt†L13-L15】【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoScreen.kt†L37-L120】
+- **Screens handle loading and error states.** The Compose layer reacts to `LoadState` to show progress and retry affordances, demonstrating awareness of resilient UI requirements.【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoScreen.kt†L37-L120】
+
+## Gaps vs. Recommended Architecture
+- **No domain layer or UI-focused models.** The ViewModel exposes raw paging data straight from the repository, tying the UI to remote DTOs (`Photo` mirrors the network schema). Google recommends introducing a domain layer and UI models to decouple presentation from transport and to hide backend changes from the UI.【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoVm.kt†L13-L15】【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/data/Photo.kt†L7-L65】
+- **UI state is not explicitly modeled.** Beyond the paging list, there is no sealed UI state (e.g., success, empty, error) surfaced from the ViewModel. The composable inspects Paging `LoadState` directly, which increases coupling and makes alternative UI (or tests) harder to implement.【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoScreen.kt†L37-L120】
+- **Configuration data is hard-coded.** The Unsplash API key lives in source code, violating security best practices and preventing per-build configuration. Recommended practice is to inject it via build config or encrypted storage.【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/data/network/NetworkModule.kt†L32-L35】
+- **Repository is thin and lacks caching.** The repository merely forwards to a network paging source with no local database or offline cache, so the app has no resilience to network loss and cannot satisfy "single source of truth" guidance.【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepo.kt†L10-L26】【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSource.kt†L20-L34】
+- **Network layer logs full payloads in all builds.** The interceptor is pinned to `BODY` level, which is discouraged for release builds and may leak PII or slow the app.【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/data/network/NetworkModule.kt†L37-L55】
+- **Leftover template code.** `MainActivity` still contains the generated `Greeting` composable that is unused, hinting at incomplete cleanup and potentially confusing future contributors.【F:app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/MainActivity.kt†L34-L37】
+- **Test coverage is absent.** There are no unit or instrumentation tests verifying repository, ViewModel, or UI behavior, which is expected for high-quality submissions.
+
+## Recommendations
+1. Introduce a domain layer (use cases or domain models) that maps from network DTOs to UI-friendly data classes; expose immutable `UiState` from the ViewModel.
+2. Secure configuration secrets by moving the API key to build config fields or remote config, and inject via `@Named` qualifiers rather than hard-coding.
+3. Add a persistence layer (Room or other) and make the repository return a cached flow to satisfy the single-source-of-truth recommendation.
+4. Provide environment-aware logging (e.g., conditional on `BuildConfig.DEBUG`).
+5. Remove template leftovers and add targeted unit tests (ViewModel, repository) plus UI tests to validate paging/error flows.
+
+Addressing these gaps would align the project much more closely with Google's modern Android architecture guidance and improve maintainability for interview reviewers.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,13 +20,26 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    val unsplashAccessKey =
+        (project.findProperty("unsplashAccessKey") as? String)
+            ?: System.getenv("UNSPLASH_ACCESS_KEY")
+            ?: ""
+
+    if (unsplashAccessKey.isBlank()) {
+        logger.warn("Unsplash access key not configured. Network calls will fail without it.")
+    }
+
     buildTypes {
+        debug {
+            buildConfigField("String", "UNSPLASH_ACCESS_KEY", "\"$unsplashAccessKey\"")
+        }
         release {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            buildConfigField("String", "UNSPLASH_ACCESS_KEY", "\"$unsplashAccessKey\"")
         }
     }
 
@@ -40,6 +53,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 
@@ -55,6 +69,7 @@ dependencies {
     // --- AndroidX core ---
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
 
     // --- Paging ---

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSource.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSource.kt
@@ -42,9 +42,9 @@ class PhotoPagingSource @Inject constructor(
             val cached = memoryCache.get(nextPageNumber)
             if (cached != null) {
                 return LoadResult.Page(
-                    data = cached,
+                    data = cached.photos,
                     prevKey = if (nextPageNumber == 1) null else nextPageNumber - 1,
-                    nextKey = if (cached.isEmpty()) null else nextPageNumber + 1
+                    nextKey = if (cached.endOfPaginationReached) null else nextPageNumber + 1
                 )
             }
 
@@ -53,11 +53,13 @@ class PhotoPagingSource @Inject constructor(
             // drop duplicates we've already emitted in this paging session
             val deduped = photos.filter { seenIds.add(it.id) }
 
-            memoryCache.put(nextPageNumber, deduped)
+            val endOfPaginationReached = photos.isEmpty()
+
+            memoryCache.put(nextPageNumber, deduped, endOfPaginationReached)
 
             LoadResult.Page(
                 data = deduped,
-                nextKey = if (deduped.isEmpty()) null else nextPageNumber + 1,
+                nextKey = if (endOfPaginationReached) null else nextPageNumber + 1,
                 prevKey = if (nextPageNumber == 1) null else nextPageNumber - 1
             )
         } catch (e: Exception) {

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSource.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSource.kt
@@ -1,14 +1,18 @@
 package com.software.pandit.lyftlaptopinterview.data
 
 import androidx.paging.PagingSource
+import androidx.paging.PagingSource.LoadParams
+import androidx.paging.PagingSource.LoadResult
 import androidx.paging.PagingState
-import com.software.pandit.lyftlaptopinterview.data.network.NetworkModule
 import com.software.pandit.lyftlaptopinterview.data.network.PhotoApi
+import com.software.pandit.lyftlaptopinterview.data.network.NetworkModule
+import com.software.pandit.lyftlaptopinterview.domain.PhotoMemoryCache
 import javax.inject.Inject
 
 class PhotoPagingSource @Inject constructor(
     val photoApi: PhotoApi,
-    @NetworkModule.ApiKey val clientId: String
+    @NetworkModule.ApiKey val clientId: String,
+    private val memoryCache: PhotoMemoryCache,
 ) : PagingSource<Int, Photo>() {
 
     private val seenIds = mutableSetOf<String>()
@@ -17,17 +21,44 @@ class PhotoPagingSource @Inject constructor(
         params: LoadParams<Int>
     ): LoadResult<Int, Photo> {
         return try {
-            // Start refresh at page 1 if undefined.
-            val nextPageNumber = params.key ?: 1
+            if (params is LoadParams.Prepend) {
+                return LoadResult.Page(
+                    data = emptyList(),
+                    prevKey = null,
+                    nextKey = params.key
+                )
+            }
+
+            val nextPageNumber = when (params) {
+                is LoadParams.Refresh -> {
+                    memoryCache.clear()
+                    seenIds.clear()
+                    params.key ?: 1
+                }
+
+                else -> params.key ?: 1
+            }
+
+            val cached = memoryCache.get(nextPageNumber)
+            if (cached != null) {
+                return LoadResult.Page(
+                    data = cached,
+                    prevKey = if (nextPageNumber == 1) null else nextPageNumber - 1,
+                    nextKey = if (cached.isEmpty()) null else nextPageNumber + 1
+                )
+            }
+
             val photos = photoApi.getPhotos(nextPageNumber, clientId)
 
             // drop duplicates we've already emitted in this paging session
             val deduped = photos.filter { seenIds.add(it.id) }
 
+            memoryCache.put(nextPageNumber, deduped)
+
             LoadResult.Page(
-                nextKey = nextPageNumber + 1,
                 data = deduped,
-                prevKey = null
+                nextKey = if (deduped.isEmpty()) null else nextPageNumber + 1,
+                prevKey = if (nextPageNumber == 1) null else nextPageNumber - 1
             )
         } catch (e: Exception) {
             LoadResult.Error(e)

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepo.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepo.kt
@@ -21,16 +21,21 @@ class PhotoRepoImpl @Inject constructor(
     private val memoryCache: PhotoMemoryCache,
 ) : PhotoRepo {
 
-    override fun getPhotos(): Flow<PagingData<PhotoSummary>> = Pager(
-        PagingConfig(
-            pageSize = 10,
-            prefetchDistance = 2,
-            enablePlaceholders = false
-        )
-    ) {
-        pagingSourceProvider.get().apply { registerInvalidatedCallback { memoryCache.clear() } }
-    }.flow.map { pagingData ->
-        pagingData.map { it.toSummary() }
+    override fun getPhotos(): Flow<PagingData<PhotoSummary>> {
+        val pageSize = 10
+
+        return Pager(
+            PagingConfig(
+                pageSize = pageSize,
+                prefetchDistance = 2,
+                enablePlaceholders = false,
+                maxSize = pageSize * 3
+            )
+        ) {
+            pagingSourceProvider.get().apply { registerInvalidatedCallback { memoryCache.clear() } }
+        }.flow.map { pagingData ->
+            pagingData.map { it.toSummary() }
+        }
     }
 
 }

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepo.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepo.kt
@@ -3,26 +3,34 @@ package com.software.pandit.lyftlaptopinterview.data
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import androidx.paging.map
+import com.software.pandit.lyftlaptopinterview.domain.PhotoMemoryCache
+import com.software.pandit.lyftlaptopinterview.domain.model.PhotoSummary
+import com.software.pandit.lyftlaptopinterview.domain.toSummary
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Provider
 
 interface PhotoRepo {
-    fun getPhotos(): Flow<PagingData<Photo>>
+    fun getPhotos(): Flow<PagingData<PhotoSummary>>
 }
 
 class PhotoRepoImpl @Inject constructor(
-    private val pagingSourceProvider: Provider<PhotoPagingSource>
+    private val pagingSourceProvider: Provider<PhotoPagingSource>,
+    private val memoryCache: PhotoMemoryCache,
 ) : PhotoRepo {
 
-    override fun getPhotos(): Flow<PagingData<Photo>> = Pager(
+    override fun getPhotos(): Flow<PagingData<PhotoSummary>> = Pager(
         PagingConfig(
             pageSize = 10,
             prefetchDistance = 2,
             enablePlaceholders = false
         )
     ) {
-        pagingSourceProvider.get()
-    }.flow
+        pagingSourceProvider.get().apply { registerInvalidatedCallback { memoryCache.clear() } }
+    }.flow.map { pagingData ->
+        pagingData.map { it.toSummary() }
+    }
 
 }

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/network/NetworkModule.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/network/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.software.pandit.lyftlaptopinterview.data.network
 
+import com.software.pandit.lyftlaptopinterview.BuildConfig
 import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
@@ -32,14 +33,22 @@ class NetworkModule {
     @Provides
     @Singleton
     @ApiKey
-    fun provideApiKey(): String = "V3sVfbkaOuBlwSD_BEqMSyJAB5gYectrTFl6-NrYyTM"
+    fun provideApiKey(): String {
+        require(BuildConfig.UNSPLASH_ACCESS_KEY.isNotBlank()) {
+            "Unsplash API key must be configured via Gradle property or UNSPLASH_ACCESS_KEY env var."
+        }
+        return BuildConfig.UNSPLASH_ACCESS_KEY
+    }
 
     @Provides
     @Singleton
     fun provideLoggingInterceptor(): HttpLoggingInterceptor =
         HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
-//            else HttpLoggingInterceptor.Level.NONE
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BODY
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
         }
 
     @Provides

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/domain/GetCuratedPhotosUseCase.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/domain/GetCuratedPhotosUseCase.kt
@@ -1,0 +1,13 @@
+package com.software.pandit.lyftlaptopinterview.domain
+
+import androidx.paging.PagingData
+import com.software.pandit.lyftlaptopinterview.data.PhotoRepo
+import com.software.pandit.lyftlaptopinterview.domain.model.PhotoSummary
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetCuratedPhotosUseCase @Inject constructor(
+    private val photoRepository: PhotoRepo
+) {
+    operator fun invoke(): Flow<PagingData<PhotoSummary>> = photoRepository.getPhotos()
+}

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMappers.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMappers.kt
@@ -1,0 +1,16 @@
+package com.software.pandit.lyftlaptopinterview.domain
+
+import com.software.pandit.lyftlaptopinterview.data.Photo
+import com.software.pandit.lyftlaptopinterview.domain.model.PhotoSummary
+
+internal fun Photo.toSummary(): PhotoSummary = PhotoSummary(
+    id = id,
+    title = description?.takeIf { it.isNotBlank() } ?: "Photo #$id",
+    description = description,
+    likes = likes,
+    width = width,
+    height = height,
+    thumbnailUrl = urls.small,
+    fullImageUrl = urls.full,
+    accentColorHex = color.takeIf { it.isNotBlank() }
+)

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMemoryCache.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMemoryCache.kt
@@ -6,13 +6,22 @@ import javax.inject.Singleton
 
 @Singleton
 class PhotoMemoryCache @Inject constructor() {
-    private val cachedPages = mutableMapOf<Int, List<Photo>>()
 
-    fun get(page: Int): List<Photo>? = synchronized(cachedPages) { cachedPages[page] }
+    data class CachedPage(
+        val photos: List<Photo>,
+        val endOfPaginationReached: Boolean,
+    )
 
-    fun put(page: Int, photos: List<Photo>) {
+    private val cachedPages = mutableMapOf<Int, CachedPage>()
+
+    fun get(page: Int): CachedPage? = synchronized(cachedPages) { cachedPages[page] }
+
+    fun put(page: Int, photos: List<Photo>, endOfPaginationReached: Boolean) {
         synchronized(cachedPages) {
-            cachedPages[page] = photos
+            cachedPages[page] = CachedPage(
+                photos = photos,
+                endOfPaginationReached = endOfPaginationReached,
+            )
         }
     }
 

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMemoryCache.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMemoryCache.kt
@@ -1,0 +1,22 @@
+package com.software.pandit.lyftlaptopinterview.domain
+
+import com.software.pandit.lyftlaptopinterview.data.Photo
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PhotoMemoryCache @Inject constructor() {
+    private val cachedPages = mutableMapOf<Int, List<Photo>>()
+
+    fun get(page: Int): List<Photo>? = synchronized(cachedPages) { cachedPages[page] }
+
+    fun put(page: Int, photos: List<Photo>) {
+        synchronized(cachedPages) {
+            cachedPages[page] = photos
+        }
+    }
+
+    fun clear() {
+        synchronized(cachedPages) { cachedPages.clear() }
+    }
+}

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/domain/model/PhotoSummary.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/domain/model/PhotoSummary.kt
@@ -1,0 +1,18 @@
+package com.software.pandit.lyftlaptopinterview.domain.model
+
+/**
+ * Domain-level representation of a photo tailored for presentation.
+ */
+data class PhotoSummary(
+    val id: String,
+    val title: String,
+    val description: String?,
+    val likes: Int,
+    val width: Int,
+    val height: Int,
+    val thumbnailUrl: String,
+    val fullImageUrl: String,
+    val accentColorHex: String?,
+) {
+    val aspectRatio: Float = if (height == 0) 1f else width.toFloat() / height
+}

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/MainActivity.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/MainActivity.kt
@@ -7,8 +7,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.software.pandit.lyftlaptopinterview.ui.photo.PhotoRoute
 import com.software.pandit.lyftlaptopinterview.ui.theme.LyftLaptopInterviewTheme
@@ -30,10 +28,4 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text("Hello $name!")
-}
-
 

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoScreenState.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoScreenState.kt
@@ -1,0 +1,9 @@
+package com.software.pandit.lyftlaptopinterview.ui.photo
+
+data class PhotoScreenState(
+    val isLoading: Boolean = true,
+    val errorMessage: String? = null,
+    val hasContent: Boolean = false,
+) {
+    val isEmpty: Boolean get() = !isLoading && !hasContent && errorMessage == null
+}

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoVm.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoVm.kt
@@ -2,16 +2,51 @@ package com.software.pandit.lyftlaptopinterview.ui.photo
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.CombinedLoadStates
+import androidx.paging.LoadState
 import androidx.paging.cachedIn
-import com.software.pandit.lyftlaptopinterview.data.PhotoRepo
-import dagger.hilt.android.internal.lifecycle.HiltViewModelMap
+import com.software.pandit.lyftlaptopinterview.domain.GetCuratedPhotosUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
-class PhotoVm @Inject constructor(val photoRepo: PhotoRepo) : ViewModel() {
+class PhotoVm @Inject constructor(
+    getCuratedPhotos: GetCuratedPhotosUseCase
+) : ViewModel() {
 
-    val photos = photoRepo.getPhotos().cachedIn(viewModelScope)
+    val photos = getCuratedPhotos().cachedIn(viewModelScope)
+
+    private val _uiState = MutableStateFlow(PhotoScreenState())
+    val uiState: StateFlow<PhotoScreenState> = _uiState.asStateFlow()
+
+    fun onLoadStatesChanged(loadStates: CombinedLoadStates) {
+        val refresh = loadStates.refresh
+        val isLoading = refresh is LoadState.Loading && !_uiState.value.hasContent
+        val errorMessage = when (refresh) {
+            is LoadState.Error -> refresh.error.localizedMessage ?: "Unable to load photos."
+            else -> null
+        }
+
+        _uiState.update { current ->
+            current.copy(
+                isLoading = isLoading,
+                errorMessage = if (current.hasContent) null else errorMessage
+            )
+        }
+    }
+
+    fun onPhotoCountChanged(count: Int) {
+        _uiState.update { current ->
+            current.copy(
+                hasContent = count > 0,
+                isLoading = if (count > 0) false else current.isLoading,
+                errorMessage = if (count > 0) null else current.errorMessage
+            )
+        }
+    }
 
 }

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMappersTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMappersTest.kt
@@ -1,0 +1,84 @@
+package com.software.pandit.lyftlaptopinterview.domain
+
+import com.google.common.truth.Truth.assertThat
+import com.software.pandit.lyftlaptopinterview.data.Photo
+import com.software.pandit.lyftlaptopinterview.data.Urls
+import org.junit.Test
+
+class PhotoMappersTest {
+
+    @Test
+    fun `maps network photo to presentation summary`() {
+        val photo = Photo(
+            blur_hash = "abc",
+            color = "#FFFFFF",
+            created_at = "2024-01-01",
+            current_user_collections = emptyList(),
+            description = "Snowy mountains",
+            height = 2000,
+            id = "photo-1",
+            liked_by_user = false,
+            likes = 42,
+            links = com.software.pandit.lyftlaptopinterview.data.Links(
+                download = "download",
+                download_location = "location",
+                html = "html",
+                self = "self"
+            ),
+            updated_at = null,
+            urls = Urls(
+                full = "full-url",
+                raw = "raw",
+                regular = "regular",
+                small = "small",
+                thumb = "thumb"
+            ),
+            width = 3000
+        )
+
+        val summary = photo.toSummary()
+
+        assertThat(summary.id).isEqualTo("photo-1")
+        assertThat(summary.title).isEqualTo("Snowy mountains")
+        assertThat(summary.description).isEqualTo("Snowy mountains")
+        assertThat(summary.thumbnailUrl).isEqualTo("small")
+        assertThat(summary.fullImageUrl).isEqualTo("full-url")
+        assertThat(summary.accentColorHex).isEqualTo("#FFFFFF")
+        assertThat(summary.aspectRatio).isWithin(0.001f).of(1.5f)
+    }
+
+    @Test
+    fun `falls back to generated title when description blank`() {
+        val photo = Photo(
+            blur_hash = "abc",
+            color = "",
+            created_at = "2024-01-01",
+            current_user_collections = emptyList(),
+            description = " ",
+            height = 100,
+            id = "42",
+            liked_by_user = false,
+            likes = 0,
+            links = com.software.pandit.lyftlaptopinterview.data.Links(
+                download = "download",
+                download_location = "location",
+                html = "html",
+                self = "self"
+            ),
+            updated_at = null,
+            urls = Urls(
+                full = "full",
+                raw = "raw",
+                regular = "regular",
+                small = "small",
+                thumb = "thumb"
+            ),
+            width = 100
+        )
+
+        val summary = photo.toSummary()
+
+        assertThat(summary.title).isEqualTo("Photo #42")
+        assertThat(summary.accentColorHex).isNull()
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMemoryCacheTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMemoryCacheTest.kt
@@ -1,0 +1,56 @@
+package com.software.pandit.lyftlaptopinterview.domain
+
+import com.google.common.truth.Truth.assertThat
+import com.software.pandit.lyftlaptopinterview.data.Photo
+import com.software.pandit.lyftlaptopinterview.data.Urls
+import org.junit.Test
+
+class PhotoMemoryCacheTest {
+
+    private val cache = PhotoMemoryCache()
+
+    @Test
+    fun `returns cached page without clearing`() {
+        val page = 1
+        val photos = listOf(
+            Photo(
+                blur_hash = "hash",
+                color = "#000000",
+                created_at = "2024-01-01",
+                current_user_collections = emptyList(),
+                description = "desc",
+                height = 10,
+                id = "id",
+                liked_by_user = false,
+                likes = 1,
+                links = com.software.pandit.lyftlaptopinterview.data.Links(
+                    download = "download",
+                    download_location = "location",
+                    html = "html",
+                    self = "self"
+                ),
+                updated_at = null,
+                urls = Urls(
+                    full = "full",
+                    raw = "raw",
+                    regular = "regular",
+                    small = "small",
+                    thumb = "thumb"
+                ),
+                width = 10
+            )
+        )
+
+        cache.put(page, photos)
+
+        assertThat(cache.get(page)).containsExactlyElementsIn(photos)
+    }
+
+    @Test
+    fun `clear removes previously cached pages`() {
+        cache.put(2, emptyList())
+        cache.clear()
+
+        assertThat(cache.get(2)).isNull()
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMemoryCacheTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/domain/PhotoMemoryCacheTest.kt
@@ -41,14 +41,18 @@ class PhotoMemoryCacheTest {
             )
         )
 
-        cache.put(page, photos)
+        cache.put(page, photos, endOfPaginationReached = false)
 
-        assertThat(cache.get(page)).containsExactlyElementsIn(photos)
+        val cached = cache.get(page)
+
+        assertThat(cached).isNotNull()
+        assertThat(cached!!.photos).containsExactlyElementsIn(photos)
+        assertThat(cached.endOfPaginationReached).isFalse()
     }
 
     @Test
     fun `clear removes previously cached pages`() {
-        cache.put(2, emptyList())
+        cache.put(2, emptyList(), endOfPaginationReached = true)
         cache.clear()
 
         assertThat(cache.get(2)).isNull()

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Configure the Unsplash API access key via this Gradle property (or UNSPLASH_ACCESS_KEY env var).
+# Leave blank and Gradle will log a warning; network calls will fail without a valid key.
+unsplashAccessKey=

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ ksp = "2.2.20-2.0.2"
 # AndroidX core
 coreKtx = "1.17.0"
 lifecycleRuntimeKtx = "2.9.4"
+lifecycleRuntimeCompose = "2.9.4"
 activityCompose = "1.11.0"
 
 # Compose
@@ -47,6 +48,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-paging = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
 
 # Compose
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }


### PR DESCRIPTION
## Summary
- add a domain layer with presentation-friendly photo models, mappers, and an in-memory cache-backed repository
- expose structured UI state from the ViewModel and update the Compose screens to render loading, empty, and error surfaces using domain models
- secure the Unsplash API key via BuildConfig, conditionally disable verbose logging, and add focused unit tests for the mapper and cache

## Testing
- `./gradlew test` *(fails: Android SDK location not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c6d4d89c8324a199971f79185573