### PR TITLE
Refactor PhotoRepo to use paging source factory

### DIFF
--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/DataModule.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/DataModule.kt
@@ -14,4 +14,9 @@ interface DataModule {
     @Binds
     fun bindPhotoRepo(photoRepoImpl: PhotoRepoImpl): PhotoRepo
 
+    @Binds
+    fun bindPhotoPagingSourceFactory(
+        factory: HiltPhotoPagingSourceFactory,
+    ): PhotoPagingSourceFactory
+
 }

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSourceFactory.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSourceFactory.kt
@@ -1,0 +1,15 @@
+package com.software.pandit.lyftlaptopinterview.data
+
+import javax.inject.Inject
+import javax.inject.Provider
+
+fun interface PhotoPagingSourceFactory {
+    fun create(): PhotoPagingSource
+}
+
+class HiltPhotoPagingSourceFactory @Inject constructor(
+    private val pagingSourceProvider: Provider<PhotoPagingSource>,
+) : PhotoPagingSourceFactory {
+
+    override fun create(): PhotoPagingSource = pagingSourceProvider.get()
+}

--- a/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepo.kt
+++ b/app/src/main/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepo.kt
@@ -10,14 +10,13 @@ import com.software.pandit.lyftlaptopinterview.domain.toSummary
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
-import javax.inject.Provider
 
 interface PhotoRepo {
     fun getPhotos(): Flow<PagingData<PhotoSummary>>
 }
 
 class PhotoRepoImpl @Inject constructor(
-    private val pagingSourceProvider: Provider<PhotoPagingSource>,
+    private val pagingSourceFactory: PhotoPagingSourceFactory,
     private val memoryCache: PhotoMemoryCache,
 ) : PhotoRepo {
 
@@ -32,7 +31,7 @@ class PhotoRepoImpl @Inject constructor(
                 maxSize = pageSize * 3
             )
         ) {
-            pagingSourceProvider.get().apply { registerInvalidatedCallback { memoryCache.clear() } }
+            pagingSourceFactory.create().apply { registerInvalidatedCallback { memoryCache.clear() } }
         }.flow.map { pagingData ->
             pagingData.map { it.toSummary() }
         }

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/PhotoFlowIntegrationTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/PhotoFlowIntegrationTest.kt
@@ -7,8 +7,10 @@ import com.google.common.truth.Truth.assertThat
 import com.software.pandit.lyftlaptopinterview.TestPhotoFactory
 import com.software.pandit.lyftlaptopinterview.data.Photo
 import com.software.pandit.lyftlaptopinterview.data.PhotoPagingSource
+import com.software.pandit.lyftlaptopinterview.data.PhotoPagingSourceFactory
 import com.software.pandit.lyftlaptopinterview.data.PhotoRepoImpl
 import com.software.pandit.lyftlaptopinterview.data.network.PhotoApi
+import com.software.pandit.lyftlaptopinterview.domain.PhotoMemoryCache
 import com.software.pandit.lyftlaptopinterview.ui.photo.PhotoVm
 import java.util.ArrayDeque
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,7 +19,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
-import javax.inject.Provider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PhotoFlowIntegrationTest {
@@ -46,7 +47,13 @@ class PhotoFlowIntegrationTest {
                 )
             )
         )
-        val repo = PhotoRepoImpl(Provider { PhotoPagingSource(api, clientId = "client") })
+        val memoryCache = PhotoMemoryCache()
+        val repo = PhotoRepoImpl(
+            pagingSourceFactory = PhotoPagingSourceFactory {
+                PhotoPagingSource(api, clientId = "client", memoryCache = memoryCache)
+            },
+            memoryCache = memoryCache,
+        )
         val viewModel = PhotoVm(repo)
 
         val differ = AsyncPagingDataDiffer(


### PR DESCRIPTION
## Summary
- add a `PhotoPagingSourceFactory` abstraction with a Hilt-provided implementation
- refactor `PhotoRepoImpl` to request the factory and update tests to inject custom paging sources

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e16619c083248c310bbab0b13188