### PR TITLE
Rewrite photo unit tests for updated implementation

### DIFF
--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/MainDispatcherRule.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/MainDispatcherRule.kt
@@ -1,0 +1,26 @@
+package com.software.pandit.lyftlaptopinterview
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val dispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        super.starting(description)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/PhotoFlowIntegrationTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/PhotoFlowIntegrationTest.kt
@@ -1,0 +1,97 @@
+package com.software.pandit.lyftlaptopinterview
+
+import androidx.paging.AsyncPagingDataDiffer
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListUpdateCallback
+import com.google.common.truth.Truth.assertThat
+import com.software.pandit.lyftlaptopinterview.TestPhotoFactory
+import com.software.pandit.lyftlaptopinterview.data.Photo
+import com.software.pandit.lyftlaptopinterview.data.PhotoPagingSource
+import com.software.pandit.lyftlaptopinterview.data.PhotoRepoImpl
+import com.software.pandit.lyftlaptopinterview.data.network.PhotoApi
+import com.software.pandit.lyftlaptopinterview.ui.photo.PhotoVm
+import java.util.ArrayDeque
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Provider
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PhotoFlowIntegrationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `photo vm exposes deduped photos from repo and paging source`() = runTest {
+        val photo1 = TestPhotoFactory.photo(id = "1")
+        val photo2 = TestPhotoFactory.photo(id = "2")
+        val duplicatePhoto2 = TestPhotoFactory.photo(id = "2")
+        val duplicateAcrossPages = TestPhotoFactory.photo(id = "2")
+        val photo3 = TestPhotoFactory.photo(id = "3")
+
+        val api = QueuePhotoApi(
+            pages = listOf(
+                listOf(
+                    photo1,
+                    photo2,
+                    duplicatePhoto2
+                ),
+                listOf(
+                    duplicateAcrossPages,
+                    photo3
+                )
+            )
+        )
+        val repo = PhotoRepoImpl(Provider { PhotoPagingSource(api, clientId = "client") })
+        val viewModel = PhotoVm(repo)
+
+        val differ = AsyncPagingDataDiffer(
+            diffCallback = object : DiffUtil.ItemCallback<Photo>() {
+                override fun areItemsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem.id == newItem.id
+                override fun areContentsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem == newItem
+            },
+            updateCallback = NoopListCallback,
+            mainDispatcher = mainDispatcherRule.dispatcher,
+            workerDispatcher = mainDispatcherRule.dispatcher
+        )
+
+        val pagingData = viewModel.photos.first()
+        differ.submitData(pagingData)
+        advanceUntilIdle()
+
+        // Trigger append load for the second page
+        differ[2]
+        advanceUntilIdle()
+
+        assertThat(api.requestedPages).containsExactly(1, 2)
+        assertThat(differ.snapshot()).containsExactly(
+            photo1,
+            photo2,
+            photo3
+        ).inOrder()
+    }
+
+    private object NoopListCallback : ListUpdateCallback {
+        override fun onInserted(position: Int, count: Int) {}
+        override fun onRemoved(position: Int, count: Int) {}
+        override fun onMoved(fromPosition: Int, toPosition: Int) {}
+        override fun onChanged(position: Int, count: Int, payload: Any?) {}
+    }
+
+    private class QueuePhotoApi(
+        pages: List<List<Photo>>
+    ) : PhotoApi {
+        private val responses = ArrayDeque(pages)
+        val requestedPages = mutableListOf<Int>()
+
+        override suspend fun getPhotos(page: Int, clientId: String): List<Photo> {
+            requestedPages += page
+            if (responses.isEmpty()) error("No response configured for page $page")
+            return responses.removeFirst()
+        }
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/TestPhotoFactory.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/TestPhotoFactory.kt
@@ -1,0 +1,78 @@
+package com.software.pandit.lyftlaptopinterview
+
+import com.software.pandit.lyftlaptopinterview.data.CurrentUserCollection
+import com.software.pandit.lyftlaptopinterview.data.Links
+import com.software.pandit.lyftlaptopinterview.data.LinksX
+import com.software.pandit.lyftlaptopinterview.data.Photo
+import com.software.pandit.lyftlaptopinterview.data.ProfileImage
+import com.software.pandit.lyftlaptopinterview.data.Urls
+
+/**
+ * Lightweight factory helpers for constructing photos and nested models in tests without
+ * repeating the huge amount of Unsplash payload boilerplate in every file.
+ */
+object TestPhotoFactory {
+
+    private val coverPhotoStub = Any()
+    private val userStub = Any()
+
+    fun photo(
+        id: String,
+        description: String? = "desc",
+        likes: Int = 0,
+        blurHash: String = "hash"
+    ): Photo = Photo(
+        blur_hash = blurHash,
+        color = "#fff",
+        created_at = "2020-01-01T00:00:00Z",
+        current_user_collections = listOf(
+            CurrentUserCollection(
+                cover_photo = coverPhotoStub,
+                id = 1,
+                last_collected_at = "2020-01-01T00:00:00Z",
+                published_at = "2020-01-01T00:00:00Z",
+                title = "title",
+                updated_at = "2020-01-01T00:00:00Z",
+                user = userStub
+            )
+        ),
+        description = description,
+        height = 100,
+        id = id,
+        liked_by_user = false,
+        likes = likes,
+        links = links(),
+        updated_at = "2020-01-02T00:00:00Z",
+        urls = urls(),
+        width = 100
+    )
+
+    fun links(): Links = Links(
+        download = "download",
+        download_location = "download_location",
+        html = "html",
+        self = "self"
+    )
+
+    fun urls(): Urls = Urls(
+        full = "full",
+        raw = "raw",
+        regular = "regular",
+        small = "small",
+        thumb = "thumb"
+    )
+
+    fun linksX(): LinksX = LinksX(
+        html = "html",
+        likes = "likes",
+        photos = "photos",
+        portfolio = "portfolio",
+        self = "self"
+    )
+
+    fun profileImage(): ProfileImage = ProfileImage(
+        large = "large",
+        medium = "medium",
+        small = "small"
+    )
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSourceTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/PhotoPagingSourceTest.kt
@@ -1,0 +1,141 @@
+package com.software.pandit.lyftlaptopinterview.data
+
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.google.common.truth.Truth.assertThat
+import com.software.pandit.lyftlaptopinterview.TestPhotoFactory
+import com.software.pandit.lyftlaptopinterview.data.network.PhotoApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PhotoPagingSourceTest {
+
+    private val photoA = TestPhotoFactory.photo(id = "A")
+    private val photoB = TestPhotoFactory.photo(id = "B")
+    private val photoC = TestPhotoFactory.photo(id = "C")
+
+    @Test
+    fun `refresh drops duplicate ids and advances to next key`() = runTest {
+        val api = RecordingPhotoApi(
+            pages = mapOf(
+                1 to listOf(photoA, photoB, TestPhotoFactory.photo(id = "B"))
+            )
+        )
+        val pagingSource = PhotoPagingSource(api, clientId = "client")
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        val page = result as PagingSource.LoadResult.Page
+        assertThat(page.prevKey).isNull()
+        assertThat(page.nextKey).isEqualTo(2)
+        assertThat(page.data).containsExactly(photoA, photoB).inOrder()
+        assertThat(api.requests)
+            .containsExactly(RecordingPhotoApi.Request(page = 1, clientId = "client"))
+    }
+
+    @Test
+    fun `append filters ids previously emitted`() = runTest {
+        val api = RecordingPhotoApi(
+            pages = mapOf(
+                1 to listOf(photoA, photoB),
+                2 to listOf(TestPhotoFactory.photo(id = "B"), photoC)
+            )
+        )
+        val pagingSource = PhotoPagingSource(api, clientId = "client")
+
+        // load first page to seed seen ids
+        pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        val append = pagingSource.load(
+            PagingSource.LoadParams.Append(
+                key = 2,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        val appendPage = append as PagingSource.LoadResult.Page
+        assertThat(appendPage.prevKey).isNull()
+        assertThat(appendPage.nextKey).isEqualTo(3)
+        assertThat(appendPage.data).containsExactly(photoC)
+        assertThat(api.requests.map { it.page }).containsExactly(1, 2).inOrder()
+    }
+
+    @Test
+    fun `load returns error result when api throws`() = runTest {
+        val failure = IllegalStateException("boom")
+        val pagingSource = PhotoPagingSource(
+            photoApi = RecordingPhotoApi(error = failure),
+            clientId = "client"
+        )
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Error::class.java)
+        val loadError = result as PagingSource.LoadResult.Error
+        assertThat(loadError.throwable).isEqualTo(failure)
+    }
+
+    @Test
+    fun `getRefreshKey returns key closest to anchor`() {
+        val pagingSource = PhotoPagingSource(RecordingPhotoApi(), clientId = "client")
+        val state = PagingState(
+            pages = listOf(
+                PagingSource.LoadResult.Page(
+                    data = listOf(photoA),
+                    prevKey = null,
+                    nextKey = 2
+                ),
+                PagingSource.LoadResult.Page(
+                    data = listOf(photoB),
+                    prevKey = 2,
+                    nextKey = 4
+                )
+            ),
+            anchorPosition = 1,
+            config = PagingConfig(pageSize = 10),
+            leadingPlaceholderCount = 0
+        )
+
+        val refreshKey = pagingSource.getRefreshKey(state)
+
+        assertThat(refreshKey).isEqualTo(3)
+    }
+
+    private class RecordingPhotoApi(
+        pages: Map<Int, List<Photo>> = emptyMap(),
+        private val error: Throwable? = null
+    ) : PhotoApi {
+        private val responses = pages.toMutableMap()
+        val requests = mutableListOf<Request>()
+
+        override suspend fun getPhotos(page: Int, clientId: String): List<Photo> {
+            requests += Request(page, clientId)
+            error?.let { throw it }
+            return responses[page].orEmpty()
+        }
+
+        data class Request(val page: Int, val clientId: String)
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepoImplTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/PhotoRepoImplTest.kt
@@ -1,0 +1,140 @@
+package com.software.pandit.lyftlaptopinterview.data
+
+import androidx.paging.AsyncPagingDataDiffer
+import androidx.paging.PagingSource
+import androidx.paging.PagingSource.LoadParams
+import androidx.paging.PagingSource.LoadResult
+import androidx.paging.PagingState
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListUpdateCallback
+import com.google.common.truth.Truth.assertThat
+import com.software.pandit.lyftlaptopinterview.MainDispatcherRule
+import com.software.pandit.lyftlaptopinterview.TestPhotoFactory
+import com.software.pandit.lyftlaptopinterview.data.network.PhotoApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Provider
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PhotoRepoImplTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val photo = TestPhotoFactory.photo(id = "from-api")
+
+    @Test
+    fun `getPhotos emits paging data provided by paging source`() = runTest {
+        val provider = RecordingProvider { RecordingPagingSource(listOf(photo)) }
+        val repo = PhotoRepoImpl(provider)
+        val differ = differ()
+
+        val job = launch {
+            repo.getPhotos().collectLatest { pagingData ->
+                differ.submitData(pagingData)
+            }
+        }
+
+        advanceUntilIdle()
+
+        assertThat(provider.invocations).isEqualTo(1)
+        assertThat(provider.lastPagingSource?.refreshCalls).isEqualTo(1)
+        assertThat(differ.snapshot()).containsExactly(photo)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `provider is invoked lazily when flow is collected`() = runTest {
+        val provider = RecordingProvider { RecordingPagingSource(listOf(photo)) }
+        val repo = PhotoRepoImpl(provider)
+
+        assertThat(provider.invocations).isEqualTo(0)
+
+        val job = launch { repo.getPhotos().collectLatest { /* no-op */ } }
+        advanceUntilIdle()
+
+        assertThat(provider.invocations).isEqualTo(1)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `new collectors receive fresh paging sources`() = runTest {
+        val provider = RecordingProvider { RecordingPagingSource(emptyList()) }
+        val repo = PhotoRepoImpl(provider)
+        val flow = repo.getPhotos()
+
+        val firstCollector = launch { flow.collectLatest { /* no-op */ } }
+        advanceUntilIdle()
+        assertThat(provider.invocations).isEqualTo(1)
+        firstCollector.cancel()
+
+        val secondCollector = launch { flow.collectLatest { /* no-op */ } }
+        advanceUntilIdle()
+        assertThat(provider.invocations).isEqualTo(2)
+
+        secondCollector.cancel()
+    }
+
+    private fun differ(): AsyncPagingDataDiffer<Photo> = AsyncPagingDataDiffer(
+        diffCallback = object : DiffUtil.ItemCallback<Photo>() {
+            override fun areItemsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem.id == newItem.id
+            override fun areContentsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem == newItem
+        },
+        updateCallback = NoopListCallback,
+        mainDispatcher = mainDispatcherRule.dispatcher,
+        workerDispatcher = mainDispatcherRule.dispatcher
+    )
+
+    private class RecordingProvider(
+        private val pagingSourceFactory: () -> RecordingPagingSource
+    ) : Provider<PhotoPagingSource> {
+        var invocations = 0
+            private set
+        var lastPagingSource: RecordingPagingSource? = null
+            private set
+
+        override fun get(): PhotoPagingSource {
+            invocations++
+            return pagingSourceFactory().also { lastPagingSource = it }
+        }
+    }
+
+    private class RecordingPagingSource(
+        private val items: List<Photo>
+    ) : PhotoPagingSource(
+        photoApi = object : PhotoApi {
+            override suspend fun getPhotos(page: Int, clientId: String): List<Photo> = items
+        },
+        clientId = "client"
+    ) {
+        var refreshCalls = 0
+            private set
+
+        override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Photo> {
+            if (params is LoadParams.Refresh) {
+                refreshCalls++
+            }
+            return LoadResult.Page(
+                data = items,
+                prevKey = null,
+                nextKey = null
+            )
+        }
+
+        override fun getRefreshKey(state: PagingState<Int, Photo>): Int? = null
+    }
+
+    private object NoopListCallback : ListUpdateCallback {
+        override fun onInserted(position: Int, count: Int) {}
+        override fun onRemoved(position: Int, count: Int) {}
+        override fun onMoved(fromPosition: Int, toPosition: Int) {}
+        override fun onChanged(position: Int, count: Int, payload: Any?) {}
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/network/NetworkModuleTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/data/network/NetworkModuleTest.kt
@@ -1,0 +1,76 @@
+package com.software.pandit.lyftlaptopinterview.data.network
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+class NetworkModuleTest {
+
+    private val module = NetworkModule()
+
+    @Test
+    fun `provideBaseUrl returns unsplash url`() {
+        val baseUrl = module.provideBaseUrl()
+        assertThat(baseUrl).isEqualTo("https://api.unsplash.com/")
+    }
+
+    @Test
+    fun `provideApiKey returns expected key`() {
+        val apiKey = module.provideApiKey()
+        assertThat(apiKey).isEqualTo("V3sVfbkaOuBlwSD_BEqMSyJAB5gYectrTFl6-NrYyTM")
+    }
+
+    @Test
+    fun `provideLoggingInterceptor sets body level`() {
+        val interceptor = module.provideLoggingInterceptor()
+        assertThat(interceptor).isInstanceOf(HttpLoggingInterceptor::class.java)
+        assertThat(interceptor.level).isEqualTo(HttpLoggingInterceptor.Level.BODY)
+    }
+
+    @Test
+    fun `provideOkHttpClient configures timeouts and interceptor`() {
+        val logging = HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.HEADERS }
+        val client = module.provideOkHttpClient(logging)
+        assertThat(client.connectTimeoutMillis.toLong()).isEqualTo(20_000)
+        assertThat(client.readTimeoutMillis.toLong()).isEqualTo(20_000)
+        assertThat(client.writeTimeoutMillis.toLong()).isEqualTo(20_000)
+        assertThat(client.interceptors).contains(logging)
+    }
+
+    @Test
+    fun `provideMoshi returns builder instance`() {
+        val moshi = module.provideMoshi()
+        assertThat(moshi).isInstanceOf(Moshi::class.java)
+    }
+
+    @Test
+    fun `provideRetrofit builds retrofit with moshi and client`() {
+        val baseUrl = module.provideBaseUrl()
+        val logging = module.provideLoggingInterceptor()
+        val client = module.provideOkHttpClient(logging)
+        val moshi = module.provideMoshi()
+
+        val retrofit = module.provideRetrofit(baseUrl, client, moshi)
+
+        assertThat(retrofit).isInstanceOf(Retrofit::class.java)
+        assertThat(retrofit.baseUrl().toString()).isEqualTo(baseUrl)
+        assertThat(retrofit.callFactory()).isEqualTo(client)
+    }
+
+    @Test
+    fun `getPhotoApi creates retrofit service`() {
+        val retrofit = Retrofit.Builder()
+            .baseUrl("https://api.unsplash.com/")
+            .client(OkHttpClient())
+            .addConverterFactory(MoshiConverterFactory.create())
+            .build()
+
+        val api = module.getPhotoApi(retrofit)
+
+        assertThat(api).isNotNull()
+    }
+}

--- a/app/src/test/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoVmTest.kt
+++ b/app/src/test/java/com/software/pandit/lyftlaptopinterview/ui/photo/PhotoVmTest.kt
@@ -1,0 +1,105 @@
+package com.software.pandit.lyftlaptopinterview.ui.photo
+
+import androidx.paging.AsyncPagingDataDiffer
+import androidx.paging.PagingData
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListUpdateCallback
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.software.pandit.lyftlaptopinterview.MainDispatcherRule
+import com.software.pandit.lyftlaptopinterview.TestPhotoFactory
+import com.software.pandit.lyftlaptopinterview.data.Photo
+import com.software.pandit.lyftlaptopinterview.data.PhotoRepo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PhotoVmTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `photos relays paging data from repository`() = runTest {
+        val repo = RecordingPhotoRepo()
+        val vm = PhotoVm(repo)
+        val differ = differ()
+        val expectedPhoto = TestPhotoFactory.photo(id = "1")
+
+        val job = launch {
+            vm.photos.collectLatest { pagingData ->
+                differ.submitData(pagingData)
+            }
+        }
+
+        repo.emit(PagingData.from(listOf(expectedPhoto)))
+        advanceUntilIdle()
+
+        assertThat(differ.snapshot()).containsExactly(expectedPhoto)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `photos caches subscription to upstream repository`() = runTest {
+        val repo = RecordingPhotoRepo()
+        val vm = PhotoVm(repo)
+        val cachedPhoto = TestPhotoFactory.photo(id = "cached")
+
+        val firstCollector = launch { vm.photos.collectLatest { } }
+        repo.emit(PagingData.from(listOf(cachedPhoto)))
+        advanceUntilIdle()
+        firstCollector.cancel()
+
+        vm.photos.test {
+            val pagingData = awaitItem()
+            val differ = differ()
+            differ.submitData(pagingData)
+            advanceUntilIdle()
+            assertThat(differ.snapshot()).containsExactly(cachedPhoto)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertThat(repo.subscriptionCount).isEqualTo(1)
+    }
+
+    private fun differ(): AsyncPagingDataDiffer<Photo> = AsyncPagingDataDiffer(
+        diffCallback = object : DiffUtil.ItemCallback<Photo>() {
+            override fun areItemsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem.id == newItem.id
+            override fun areContentsTheSame(oldItem: Photo, newItem: Photo): Boolean = oldItem == newItem
+        },
+        updateCallback = NoopListCallback,
+        mainDispatcher = mainDispatcherRule.dispatcher,
+        workerDispatcher = mainDispatcherRule.dispatcher
+    )
+
+    private object NoopListCallback : ListUpdateCallback {
+        override fun onInserted(position: Int, count: Int) {}
+        override fun onRemoved(position: Int, count: Int) {}
+        override fun onMoved(fromPosition: Int, toPosition: Int) {}
+        override fun onChanged(position: Int, count: Int, payload: Any?) {}
+    }
+
+    private class RecordingPhotoRepo : PhotoRepo {
+        private val upstream = MutableSharedFlow<PagingData<Photo>>(replay = 1)
+        var subscriptionCount = 0
+            private set
+
+        override fun getPhotos(): Flow<PagingData<Photo>> = upstream
+            .onSubscription { subscriptionCount++ }
+            .asSharedFlow()
+
+        suspend fun emit(data: PagingData<Photo>) {
+            upstream.emit(data)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refresh `PhotoPagingSourceTest` to assert duplicate filtering, next-key progression, and error handling against a recording API
- update `PhotoRepoImplTest` to verify lazy provider usage, fresh paging sources per collector, and emitted items via an `AsyncPagingDataDiffer`
- rewrite `PhotoVmTest` to confirm repository paging data is relayed while cached subscriptions prevent redundant upstream work

## Testing
- `./gradlew test` *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c7b3c954832482c199d048f17453